### PR TITLE
Dependabot で、GitHub Actions ワークフローで使用しているアクションについても更新できるように設定

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,17 @@ updates:
           - "nadesiko3"
           - "nadesiko3-*"
     versioning-strategy: increase # 常に package.json に記載してあるバージョンも書き換える
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:00'
+      timezone: Asia/Tokyo
+    cooldown:
+      default-days: 7
+    groups:
+      official-actions:
+        patterns:
+          - "actions/*"


### PR DESCRIPTION
GitHub Actions ワークフロー内で使用しているアクション（例えば `actions/checkout`）のバージョンの更新を Dependabot にやってもらうための設定を追加しました。