### PR TITLE
GitHub Actions ワークフロー内の `actions/checkout` アクションで、認証情報を保持しない（すぐに破棄する）ように設定

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
       - name: リポジトリのチェックアウト
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          # 後続の操作では認証情報を使用しないため、破棄するように設定
+          persist-credentials: false
 
       - name: Node.js のセットアップ
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0


### PR DESCRIPTION
認証情報をすぐに破棄することで少しだけセキュリティの向上が見込めると思われます。

参考: https://zenn.dev/shunsuke_suzuki/articles/github-action-checkout-persist-credentials