### PR TITLE
ユニットテストを実行する GitHub Actions ワークフローで、ジョブに名前が設定されていなかったので設定

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ defaults:
 
 jobs:
   test:
+    name: ユニットテストの実行
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
`jobs.<job_id>.name` の値が設定されていなかったので設定しました（設定しなくてもそんなに問題ないとは思いますが）。