### PR TITLE
`node:test` モジュールの `test` 関数をなでしこ側から利用するためのプラグインを用意し、それを利用してユニットテストを書き換えた

### DIFF
--- a/fizzbuzz.test.nako3
+++ b/fizzbuzz.test.nako3
@@ -1,29 +1,33 @@
 !厳しくチェック。
+!「simple-test-plugin.js」を取り込む。
 !「fizzbuzz.nako3」を取り込む。
 
-1のFizzBuzzと「1」がASSERT等しい。
-2のFizzBuzzと「2」がASSERT等しい。
-3のFizzBuzzと「Fizz」がASSERT等しい。
-4のFizzBuzzと「4」がASSERT等しい。
-5のFizzBuzzと「Buzz」がASSERT等しい。
-6のFizzBuzzと「Fizz」がASSERT等しい。
-7のFizzBuzzと「7」がASSERT等しい。
-8のFizzBuzzと「8」がASSERT等しい。
-9のFizzBuzzと「Fizz」がASSERT等しい。
-10のFizzBuzzと「Buzz」がASSERT等しい。
-11のFizzBuzzと「11」がASSERT等しい。
-12のFizzBuzzと「Fizz」がASSERT等しい。
-13のFizzBuzzと「13」がASSERT等しい。
-14のFizzBuzzと「14」がASSERT等しい。
-15のFizzBuzzと「FizzBuzz」がASSERT等しい。
+「FizzBuzz関数の出力が正しいこと」のテスト実行時には
+　　1のFizzBuzzと「1」がASSERT等しい。
+　　2のFizzBuzzと「2」がASSERT等しい。
+　　3のFizzBuzzと「Fizz」がASSERT等しい。
+　　4のFizzBuzzと「4」がASSERT等しい。
+　　5のFizzBuzzと「Buzz」がASSERT等しい。
+　　6のFizzBuzzと「Fizz」がASSERT等しい。
+　　7のFizzBuzzと「7」がASSERT等しい。
+　　8のFizzBuzzと「8」がASSERT等しい。
+　　9のFizzBuzzと「Fizz」がASSERT等しい。
+　　10のFizzBuzzと「Buzz」がASSERT等しい。
+　　11のFizzBuzzと「11」がASSERT等しい。
+　　12のFizzBuzzと「Fizz」がASSERT等しい。
+　　13のFizzBuzzと「13」がASSERT等しい。
+　　14のFizzBuzzと「14」がASSERT等しい。
+　　15のFizzBuzzと「FizzBuzz」がASSERT等しい。
 
-100のFizzBuzzと「Buzz」がASSERT等しい。
-101のFizzBuzzと「101」がASSERT等しい。
-102のFizzBuzzと「Fizz」がASSERT等しい。
-103のFizzBuzzと「103」がASSERT等しい。
-104のFizzBuzzと「104」がASSERT等しい。
-105のFizzBuzzと「FizzBuzz」がASSERT等しい。
+　　100のFizzBuzzと「Buzz」がASSERT等しい。
+　　101のFizzBuzzと「101」がASSERT等しい。
+　　102のFizzBuzzと「Fizz」がASSERT等しい。
+　　103のFizzBuzzと「103」がASSERT等しい。
+　　104のFizzBuzzと「104」がASSERT等しい。
+　　105のFizzBuzzと「FizzBuzz」がASSERT等しい。
+ここまで。
 
-# プラグインスコープを利用した呼び出しができることのテスト
-1のfizzbuzz__FizzBuzzと「1」がASSERT等しい。
-5のfizzbuzz__FizzBuzzと「Buzz」がASSERT等しい。
+「プラグインスコープを利用してFizzBuzz関数を呼び出せること」のテスト実行時には
+　　1のfizzbuzz__FizzBuzzと「1」がASSERT等しい。
+　　5のfizzbuzz__FizzBuzzと「Buzz」がASSERT等しい。
+ここまで。

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "name": "nadesiko3-fizzbuzz",
   "version": "1.0.0",
+  "type": "module",
   "engines": {
     "node": ">=24.0.0"
   },
@@ -9,6 +10,6 @@
     "nadesiko3": "^3.7.8"
   },
   "scripts": {
-    "test": "RESULT=$(cnako3 fizzbuzz.test.nako3) && echo \"$RESULT\" && ! echo \"$RESULT\" | grep -q 'AssertionError'"
+    "test": "cnako3 fizzbuzz.test.nako3"
   }
 }

--- a/simple-test-plugin.js
+++ b/simple-test-plugin.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+
+export default {
+  meta: {
+    type: "const",
+    value: {
+      pluginName: "simple-test-plugin",
+      description: "ユニットテスト実行用の簡易プラグイン。",
+      pluginVersion: "0.0.0",
+      nakoRuntime: ["cnako"],
+      nakoVersion: "3.7.8",
+    },
+  },
+
+  テスト実行時: {
+    // @テストを定義するための関数。単に `node:test` モジュールの `test` 関数を呼び出すだけです。 // @てすとじっこうしたとき
+    type: "func",
+    josi: [["を"], ["の"]],
+    fn: function (testFunc, testName, sys) {
+      // `testFunc` 引数の型は
+      //
+      // - 無名関数 `……には` を利用して呼び出した場合は `function`
+      // - `「関数名」を「テスト名」のテスト実行時` の形で呼び出した場合は `string`
+      //
+      // となる。後者の場合は `sys.__findFunc()` を用いて関数を取得する。
+      const f = (() => {
+        if (typeof testFunc === "function") {
+          return testFunc;
+        }
+        if (typeof testFunc === "string") {
+          const tf = sys.__findFunc(testFunc, "テスト実行時");
+          if (typeof tf === "function") {
+            return tf;
+          }
+        }
+        throw new Error(
+          "『テスト実行時』関数の第一引数には関数名を文字列で指定するか、無名関数（……には）を用いてください。"
+        );
+      })();
+
+      test(testName, f);
+    },
+  },
+};


### PR DESCRIPTION
Node.js の標準ライブラリに含まれている `node:test` モジュール内の `test` 関数をなでしこ側から利用するためのプラグイン (`simple-test-plugin.js`) を用意し、それを利用してユニットテストを書き換えた。

またこれにより `cnako3 fizzbuzz.test.nako3` コマンドでのテスト失敗時（`ASSERT等しい` 関数が `AssertionError` を投げたとき）に終了コードが 0 以外になるようになったため、`npm test` スクリプトを実行した時のコマンドを少し簡素にすることができるようになった。

ただし、本来 `node:test` モジュールを使用して定義されたテストは `node --test` のように `node` コマンドを `--test` オプション付きで実行されるのが望ましいと思われる。`cnako3 fizzbuzz.test.nako3` コマンドでユニットテストを実行した際はこの `--test` オプションに相当するものが付与されないと思われるため、一部の機能は正常に動作しないかもしれない。